### PR TITLE
added one final try if everything fails

### DIFF
--- a/includes/islandora_fits.process.inc
+++ b/includes/islandora_fits.process.inc
@@ -73,6 +73,13 @@ function islandora_fits_create_fits($file) {
   if ($ret == "0") {
     return $outfile;
   }
+  // in case of disaster, fall back to the simplest possibly command line
+  $command = variable_get("islandora_fits_executable_path", "fits.sh") . " -i "
+    . $file . " -o " . $outfile;
+  exec($command, $output, $ret);
+  if ($ret == "0") {
+    return $outfile;
+  }
   return FALSE;
 }
 


### PR DESCRIPTION
Sometimes fits generation fails because of -xc or -x, if both of those happen, we can try not using the -x option at all (which will disable extraction of some metadata).  But this might help in the case of https://jira.duraspace.org/browse/ISLANDORA-829
