### PR TITLE
Windows-compatibility: Calling the FITS processor through the command line

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -87,12 +87,10 @@ function islandora_fits_path_check($fits_path) {
 
   $command = 'stat ' . $fits_path;
 
-  // Determine if the server's operating system is Windows.
+  // Ensure that this is a Windows server and that $fits_path isn't
+  // pointing to a shell script (that combo may cause the page to hang).
   if ((islandora_deployed_on_windows()) && (strpos($fits_path, ".sh") === FALSE)) {
-    // In Windows, $command returns the message: "'stat' is not recognized
-    // as an internal or external command, operable program or batch file."
-    // The updated $command (below) returns FITS version information, which
-    // is enough to verify that the FITS processing script was found.
+    // Validate FITS by requesting version info instead.
     $command = $fits_path . ' -v';
   }
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -83,13 +83,26 @@ function islandora_fits_path_ajax($form, $form_state) {
 function islandora_fits_path_check($fits_path) {
   $output = array();
   $return_value = '';
-  exec('stat ' . $fits_path, $output, $return_value);
+
+  // Updated: slangerx, 2013-11-08
+  $command = 'stat ' . $fits_path;
+
+  // Determine if the server is running Windows.
+  if ((islandora_os_check() == "Windows") && (strpos($fits_path, ".sh") === FALSE)) {
+    // In Windows, $command returns the message: "'stat' is not recognized
+    // as an internal or external command, operable program or batch file."
+    // The updated $command (below) returns FITS version information, which
+    // is enough to verify that the FITS processing script was found.
+    $command = $fits_path . ' -v';
+  }
+
+  exec($command, $output, $return_value);
 
   if ($return_value !== 0) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate fits.sh at the above location!');
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate ' . ((islandora_os_check() == "Windows") ? 'fits.bat' : 'fits.sh') . ' at the above location!');
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('Found fits.sh at the above location!');
+    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('Found ' . ((islandora_os_check() == "Windows") ? 'fits.bat' : 'fits.sh') . ' at the above location!');
   }
   return $confirmation_message;
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -97,10 +97,10 @@ function islandora_fits_path_check($fits_path) {
   exec($command, $output, $return_value);
 
   if ($return_value !== 0) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the FITS processing script at @fitspath', array('@fitspath' => $fits_path));
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the File Information Tool Set at @fitspath', array('@fitspath' => $fits_path));
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('FITS processing script found at @fitspath', array('@fitspath' => $fits_path));
+    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('File Information Tool Set found at @fitspath', array('@fitspath' => $fits_path));
   }
   return $confirmation_message;
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -84,7 +84,7 @@ function islandora_fits_path_check($fits_path) {
   $output = array();
   $return_value = '';
 
-  // Updated: slanger, 2013-11-08
+  // Updated: slangerx, 2013-11-08
   $command = 'stat ' . $fits_path;
 
   // Determine if the server is running Windows.

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -81,14 +81,14 @@ function islandora_fits_path_ajax($form, $form_state) {
  * Checks a fits path for the executable. 
  */
 function islandora_fits_path_check($fits_path) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $output = array();
   $return_value = '';
 
-  // Updated: slangerx, 2013-11-08
   $command = 'stat ' . $fits_path;
 
-  // Determine if the server is running Windows.
-  if ((islandora_os_check() == "Windows") && (strpos($fits_path, ".sh") === FALSE)) {
+  // Determine if the server's operating system is Windows.
+  if ((islandora_deployed_on_windows()) && (strpos($fits_path, ".sh") === FALSE)) {
     // In Windows, $command returns the message: "'stat' is not recognized
     // as an internal or external command, operable program or batch file."
     // The updated $command (below) returns FITS version information, which

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -84,7 +84,7 @@ function islandora_fits_path_check($fits_path) {
   $output = array();
   $return_value = '';
 
-  // Updated: slangerx, 2013-11-08
+  // Updated: slanger, 2013-11-08
   $command = 'stat ' . $fits_path;
 
   // Determine if the server is running Windows.
@@ -99,10 +99,10 @@ function islandora_fits_path_check($fits_path) {
   exec($command, $output, $return_value);
 
   if ($return_value !== 0) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate ' . ((islandora_os_check() == "Windows") ? 'fits.bat' : 'fits.sh') . ' at the above location!');
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the FITS processing script at ' . $fits_path);
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('Found ' . ((islandora_os_check() == "Windows") ? 'fits.bat' : 'fits.sh') . ' at the above location!');
+    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('FITS processing script found at ' . $fits_path);
   }
   return $confirmation_message;
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -99,10 +99,10 @@ function islandora_fits_path_check($fits_path) {
   exec($command, $output, $return_value);
 
   if ($return_value !== 0) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the FITS processing script at ' . $fits_path);
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the FITS processing script at @fitspath', array('@fitspath' => $fits_path));
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('FITS processing script found at ' . $fits_path);
+    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('FITS processing script found at @fitspath', array('@fitspath' => $fits_path));
   }
   return $confirmation_message;
 }


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

**Command line:** When the FITS processor is called through the command line, some of the syntax is very *NIX-specific and fails under Windows. To be more specific, the following error is returned:

> " 'stat' is not recognized as an internal or external command, operable program or batch file."

This patch corrects that problem.

**Confirmation message:** By default, after the system path to FITS has been tested, the confirmation message always refers to `fits.sh`. The problem is, Windows actually use `fits.bat`. Because of this, I've recommended some changes to the confirmation message that will accommodate both operating systems.

_NOTE:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
