### PR TITLE
ISLANDORA-1534: proposed fix

### DIFF
--- a/islandora_fits.module
+++ b/islandora_fits.module
@@ -240,10 +240,8 @@ function islandora_fits_children($child, &$output) {
                 $output[$tool_label][$field_label][] = $output_text;
               }
               else {
-                foreach ($output[$tool_label][$field_label] as $key => $value) {
-                  if ($value !== $output_text) {
-                    $output[$tool_label][$field_label][] = $output_text;
-                  }
+                if (!in_array($output_text, $output[$tool_label][$field_label])) {
+                  $output[$tool_label][$field_label][] = $output_text;
                 }
               }
             }
@@ -254,10 +252,8 @@ function islandora_fits_children($child, &$output) {
           // No tool attribute.
           else {
             if (isset($output['Unknown'][$field_label])) {
-              foreach ($output['Unknown'][$field_label] as $value) {
-                if ($value !== $output_text) {
-                  $output['Unknown'][$field_label][] = $output_text;
-                }
+              if (!in_array($output_text, $output['Unknown'][$field_label])) {
+                $output['Unknown'][$field_label][] = $output_text;
               }
             }
             else {


### PR DESCRIPTION
Jira: https://jira.duraspace.org/browse/ISLANDORA-1534
## What does this Pull Request do?

When displaying techmd metadata on the "technical metadata" tab, the islandora_fits_children() function loops through the tool/field/values in the recursed xml, and is supposed to be testing to see if there are any identical values previously existing in the array at $output[$tool_label][$field_label]. If so, it's supposed to skip adding the new value. 

However, the code does not do this. It loops through the existing values at that tool/field, and if **any** of them do not match the current value, it will add the current value. If the metadata includes multiple fields with the same label, his results in an unbounded loop.

This proposed fix uses _in_array()_ to determine the presence of the label.
## How should this be tested?
- Add a techmd datastream that exhibits this property of having multiple identical field labels. Here is an example: https://jira.duraspace.org/secure/attachment/17542/fits-techmd-content.xml.
- Prior to application of this patch, clicking on the "Technical metadata" tab will cause a white screen. After application of the patch, you will see the techmd metadata.
## Additional Notes:
- **Does this change require documentation to be updated?** No
- **Could this change impact execution of existing code?** No

Tagging:
- **@ruebot** (component manager)
- **@DiegoPino**

Pat Dunlavey
Common Media Inc.
