### PR TITLE
Resolve ISLANDORA-1606.

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -21,7 +21,8 @@
  * @see hook_islandora_derivative()
  */
 function islandora_fits_create_techmd(AbstractObject $object, $force = FALSE, $hook = array()) {
-  if ($force || !isset($object['TECHMD'])) {
+  $techmd_dsid = variable_get('islandora_fits_techmd_dsid', 'TECHMD');
+  if ($force || !isset($object[$techmd_dsid])) {
     if (!isset($object[$hook['source_dsid']])) {
       return array(
         'success' => FALSE,

--- a/islandora_fits.module
+++ b/islandora_fits.module
@@ -62,7 +62,7 @@ function islandora_fits_islandora_derivative() {
   return array(
     array(
       'source_dsid' => 'OBJ',
-      'destination_dsid' => 'TECHMD',
+      'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
       'weight' => '0',
       'function' => array(
         'islandora_fits_create_techmd',
@@ -79,7 +79,7 @@ function islandora_fits_ir_citationcmodel_islandora_derivative() {
   return array(
     array(
       'source_dsid' => 'PDF',
-      'destination_dsid' => 'TECHMD',
+      'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
       'weight' => '0.01',
       'function' => array(
         'islandora_fits_create_techmd',


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1606 
# What does this Pull Request do?

Uses `islandora_fits_techmd_dsid` value instead of hard-coded value of `TECHMD` for the `islandora_derivative` and `ir_citationcmodel_islandora_derivative` hooks.
# How should this be tested?

Set the value for "Technical metadata datastream ID" at admin/islandora/tools/fits to something other than `TECHMD`, the create an object, go to manage/datastreams on the object, and verify that there is a regenerate link for the dsid.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @Islandora/7-x-1-x-committers 
