### PR TITLE
ISLANDORA-1604 Travis Failing for PHP 5.3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_install:
 script:
   - ant -buildfile sites/all/modules/islandora_fits/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_fits
-  - drush dcs sites/all/modules/islandora_fits
+  - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_fits
   - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_fits
   - drush test-run --uri=http://localhost:8081 "Islandora FITS"


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1804
- As discussed on IRC Sept 19-20, 2016
# What does this Pull Request do?

Changes the command run by Travis from `drush dcs` to `drush coder-review` to match other modules, since it's causing Travis to fail on PHP 5.3.3. 
# What's new?

One-line change in .travis.yml
# How should this be tested?

Run Travis CI. If it doesn't fail in 5.3.3. (and only 5.3.3) then we've solved it. 
# Additional Notes:
- Does this change require documentation to be updated? No.
- Does this change add any new dependencies? No.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No. 
- Could this change impact execution of existing code? No. 
# Interested parties

@dannylamb @whikloj 
