### PR TITLE
ISLANDORA-1999 Improved admin form validation.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -98,7 +98,7 @@ function islandora_fits_admin_submit_form($form, &$form_state) {
   }
   // Conditionally set the FITS executable path.
   if ($form_state['values']['islandora_fits_do_derivatives']) {
-    variable_set('islandora_fits_executable_path',$form_state['values']['islandora_fits_executable_path']);
+    variable_set('islandora_fits_executable_path', $form_state['values']['islandora_fits_executable_path']);
   }
   drupal_set_message(t('The settings have been updated!'));
 }
@@ -119,7 +119,7 @@ function islandora_fits_get_path_message($fits_path) {
     $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/> ' . t('Executable found at @fitspath', array('@fitspath' => $fits_path));
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/> ' . join('<br/>', $errors);
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/> ' . implode('<br/>', $errors);
   }
   return $confirmation_message;
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -25,7 +25,7 @@ function islandora_fits_admin_form($form, $form_state) {
     '#type' => 'checkbox',
     '#title' => t('Run Islandora FITS derivatives locally'),
     '#name' => 'islandora_fits_do_derivatives',
-    '#description' => t('Uncheck if FITS is not installed on this system, or if technical metadata extraction is being done elsewhere.'),
+    '#description' => t('If checked (default), this server will use FITS to create a technical metadata datastream (the datastream id of which is defined below). Requires a local installation of the FITS tool.'),
     '#return_value' => 1,
     '#default_value' => variable_get('islandora_fits_do_derivatives', 1),
   );
@@ -37,7 +37,7 @@ function islandora_fits_admin_form($form, $form_state) {
     '#type' => 'textfield',
     '#title' => t('System path to FITS processor'),
     '#name' => 'islandora_fits_path_textfield',
-    '#description' => t('Enter the location and filename (on the system) of the FITS processing script. Include the filename, not just the path.'),
+    '#description' => t('The complete path and filename of the File Information Tool Set (FITS) binary, or the command to run if in the path.'),
     '#default_value' => $fits_path,
     '#ajax' => array(
       'callback' => 'islandora_fits_path_ajax',
@@ -62,7 +62,7 @@ function islandora_fits_admin_form($form, $form_state) {
   $form['islandora_fits_techmd_dsid'] = array(
     '#type' => 'textfield',
     '#title' => t('Technical metadata datastream ID'),
-    '#description' => t("The DSID to use for an object's technical metadata."),
+    '#description' => t("The DSID to use when creating or displaying an object's technical metadata."),
     '#default_value' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
   );
   // Add options to include/exclude certain mimetypes/extensions/solution packs.
@@ -76,13 +76,12 @@ function islandora_fits_admin_form($form, $form_state) {
  * Validation handler for Fits admin form.
  */
 function islandora_fits_admin_form_validate($form, &$form_state) {
+  // Only validate the FITS path if doing derivatives.
   if ($form_state['values']['islandora_fits_do_derivatives']) {
-    if (!islandora_fits_path_check($form_state['values']['islandora_fits_executable_path'])) {
-      form_set_error('islandora_fits_path_textfield', "Path to FITS is not valid. Provide a valid path or disable FITS derivatives.");
+    $errors = islandora_fits_path_check($form_state['values']['islandora_fits_executable_path']);
+    if (!empty($errors)) {
+      form_set_error('islandora_fits_executable_path', "FITS path is not valid. Provide a valid path or disable FITS derivatives.");
     }
-  }
-  else {
-    // TODO: Clear the fits executable path?
   }
 }
 
@@ -92,11 +91,14 @@ function islandora_fits_admin_form_validate($form, &$form_state) {
 function islandora_fits_admin_submit_form($form, &$form_state) {
   $variables = array(
     'islandora_fits_do_derivatives',
-    'islandora_fits_executable_path',
     'islandora_fits_techmd_dsid',
   );
   foreach ($variables as $variable) {
     variable_set($variable, $form_state['values'][$variable]);
+  }
+  // Conditionally set the FITS executable path.
+  if ($form_state['values']['islandora_fits_do_derivatives']) {
+    variable_set('islandora_fits_executable_path',$form_state['values']['islandora_fits_executable_path']);
   }
   drupal_set_message(t('The settings have been updated!'));
 }
@@ -112,11 +114,12 @@ function islandora_fits_path_ajax($form, $form_state) {
  * Gets a user-friendly message to show whether the path is valid.
  */
 function islandora_fits_get_path_message($fits_path) {
-  if (islandora_fits_path_check($fits_path)) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('File Information Tool Set found at @fitspath', array('@fitspath' => $fits_path));
+  $errors = islandora_fits_path_check($fits_path);
+  if (empty($errors)) {
+    $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/> ' . t('Executable found at @fitspath', array('@fitspath' => $fits_path));
   }
   else {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the File Information Tool Set at @fitspath', array('@fitspath' => $fits_path));
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/> ' . join('<br/>', $errors);
   }
   return $confirmation_message;
 }
@@ -124,13 +127,42 @@ function islandora_fits_get_path_message($fits_path) {
 /**
  * Checks fits path for an executable.
  *
- * Returns true if the path is an executable, false otherwise.
+ * @param string $path
+ *   Path to a desired executable, or executable string.
+ *
+ * @return array
+ *   Errors encountered executing the file. If it returns an empty array,
+ *   then the file was executable.
  */
-function islandora_fits_path_check($fits_path) {
-  if (is_executable($fits_path)) {
-    return TRUE;
+function islandora_fits_path_check($path) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $allowed_paths = array(
+    'fits.sh',
+    'fits',
+  );
+  $errors = array();
+  if (!in_array($path, $allowed_paths)) {
+    // Check whether the given file exists.
+    if (!is_file($path)) {
+      $errors[] = t('The specified file path %file does not exist.', array('%file' => $path));
+    }
+    // If it exists, check if it's executable.
+    elseif (!is_executable($path)) {
+      $errors[] = t('The specified file path %file is not executable.', array('%file' => $path));
+    }
   }
-  else {
-    return FALSE;
+  // Ensure that if this is a Windows server, $file isn't pointing to a
+  // shell script (that combo may cause the page to hang).
+  if ((islandora_deployed_on_windows()) && (strpos($path, ".sh") == FALSE)) {
+    $errors[] = t('Islandora appears to be running on Windows, but the path given ends in .sh.');
   }
+  // If we haven't had errors so far, try executing it with the -v option.
+  if (empty($errors)) {
+    $command = $path . ' -v';
+    exec($command, $output, $return_value);
+    if ($return_value !== 0) {
+      $errors[] = t('The command %file is not a valid FITS executable.', array('%file' => $path));
+    }
+  }
+  return $errors;
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implementation of a form. 
+ * Admin form for Islandora FITS configuration.
  *
  * @see drupal_get_form
  */
@@ -20,7 +20,15 @@ function islandora_fits_admin_form($form, $form_state) {
   else {
     $fits_path = variable_get('islandora_fits_executable_path', 'fits.sh');
   }
-  $conf_message = islandora_fits_path_check($fits_path);
+  $conf_message = islandora_fits_get_path_message($fits_path);
+  $form['islandora_fits_do_derivatives'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Run Islandora FITS derivatives locally'),
+    '#name' => 'islandora_fits_do_derivatives',
+    '#description' => t('Uncheck if FITS is not installed on this system, or if technical metadata extraction is being done elsewhere.'),
+    '#return_value' => 1,
+    '#default_value' => variable_get('islandora_fits_do_derivatives', 1),
+  );
   $form['islandora_fits_wrapper'] = array(
     '#prefix' => '<div id="islandora_fits_wrapper">',
     '#suffix' => '</div>',
@@ -35,9 +43,20 @@ function islandora_fits_admin_form($form, $form_state) {
       'callback' => 'islandora_fits_path_ajax',
       'wrapper' => 'islandora_fits_wrapper',
     ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_fits_do_derivatives"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   $form['islandora_fits_wrapper']['islandora_fits_path_check'] = array(
+    '#type' => 'item',
     '#markup' => $conf_message,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_fits_do_derivatives"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   // Add form options for what the datastream is called.
   $form['islandora_fits_techmd_dsid'] = array(
@@ -54,53 +73,64 @@ function islandora_fits_admin_form($form, $form_state) {
 }
 
 /**
+ * Validation handler for Fits admin form.
+ */
+function islandora_fits_admin_form_validate($form, &$form_state) {
+  if ($form_state['values']['islandora_fits_do_derivatives']) {
+    if (!islandora_fits_path_check($form_state['values']['islandora_fits_executable_path'])) {
+      form_set_error('islandora_fits_path_textfield', "Path to FITS is not valid. Provide a valid path or disable FITS derivatives.");
+    }
+  }
+  else {
+    // TODO: Clear the fits executable path?
+  }
+}
+
+/**
  * Form submit handler.
- *
- * @todo Should probably check the fits executable to validate it. 
- * @todo Should we just be using a system settings form instead of this.
  */
 function islandora_fits_admin_submit_form($form, &$form_state) {
-  // Should probably check that the fits executable is correct.
-  foreach ($form_state['values'] as $key => $value) {
-    if (is_array($value) && isset($form_state['values']['array_filter'])) {
-      $value = array_keys(array_filter($value));
-    }
-    variable_set($key, $value);
+  $variables = array(
+    'islandora_fits_do_derivatives',
+    'islandora_fits_executable_path',
+    'islandora_fits_techmd_dsid',
+  );
+  foreach ($variables as $variable) {
+    variable_set($variable, $form_state['values'][$variable]);
   }
   drupal_set_message(t('The settings have been updated!'));
 }
 
 /**
- * Ajax handler for admin form. 
+ * Ajax handler for admin form.
  */
 function islandora_fits_path_ajax($form, $form_state) {
   return $form['islandora_fits_wrapper'];
 }
 
 /**
- * Checks a fits path for the executable. 
+ * Gets a user-friendly message to show whether the path is valid.
  */
-function islandora_fits_path_check($fits_path) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  $output = array();
-  $return_value = '';
-
-  $command = 'stat ' . $fits_path;
-
-  // Ensure that this is a Windows server and that $fits_path isn't
-  // pointing to a shell script (that combo may cause the page to hang).
-  if ((islandora_deployed_on_windows()) && (strpos($fits_path, ".sh") === FALSE)) {
-    // Validate FITS by requesting version info instead.
-    $command = $fits_path . ' -v';
-  }
-
-  exec($command, $output, $return_value);
-
-  if ($return_value !== 0) {
-    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the File Information Tool Set at @fitspath', array('@fitspath' => $fits_path));
-  }
-  else {
+function islandora_fits_get_path_message($fits_path) {
+  if (islandora_fits_path_check($fits_path)) {
     $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>' . t('File Information Tool Set found at @fitspath', array('@fitspath' => $fits_path));
   }
+  else {
+    $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/>' . t('Unable to locate the File Information Tool Set at @fitspath', array('@fitspath' => $fits_path));
+  }
   return $confirmation_message;
+}
+
+/**
+ * Checks fits path for an executable.
+ *
+ * Returns true if the path is an executable, false otherwise.
+ */
+function islandora_fits_path_check($fits_path) {
+  if (is_executable($fits_path)) {
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
 }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -21,6 +21,18 @@
  * @see hook_islandora_derivative()
  */
 function islandora_fits_create_techmd(AbstractObject $object, $force = FALSE, $hook = array()) {
+  if (!variable_get('islandora_fits_do_derivatives', TRUE)) {
+    return array(
+      'success' => TRUE,
+      'messages' => array(
+        array(
+          'message' => t('Islandora FITS derivatives disabled: Technical metadata extraction skipped.'),
+          'type' => 'watchdog',
+          'severity' => WATCHDOG_NOTICE,
+        ),
+      ),
+    );
+  }
   $techmd_dsid = variable_get('islandora_fits_techmd_dsid', 'TECHMD');
   if ($force || !isset($object[$techmd_dsid])) {
     if (!isset($object[$hook['source_dsid']])) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -21,18 +21,6 @@
  * @see hook_islandora_derivative()
  */
 function islandora_fits_create_techmd(AbstractObject $object, $force = FALSE, $hook = array()) {
-  if (!variable_get('islandora_fits_do_derivatives', TRUE)) {
-    return array(
-      'success' => TRUE,
-      'messages' => array(
-        array(
-          'message' => t('Islandora FITS derivatives disabled: Technical metadata extraction skipped.'),
-          'type' => 'watchdog',
-          'severity' => WATCHDOG_NOTICE,
-        ),
-      ),
-    );
-  }
   $techmd_dsid = variable_get('islandora_fits_techmd_dsid', 'TECHMD');
   if ($force || !isset($object[$techmd_dsid])) {
     if (!isset($object[$hook['source_dsid']])) {

--- a/islandora_fits.install
+++ b/islandora_fits.install
@@ -12,6 +12,7 @@ function islandora_fits_uninstall() {
   $variables = array(
     'islandora_fits_techmd_dsid',
     'islandora_fits_executable_path',
+    'islandora_fits_do_derivatives',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_fits.module
+++ b/islandora_fits.module
@@ -61,15 +61,15 @@ function islandora_fits_theme() {
 function islandora_fits_islandora_derivative() {
   $derivatives = array();
   if (variable_get('islandora_fits_do_derivatives', TRUE)) {
-      $derivatives[] = array(
-        'source_dsid' => 'OBJ',
-        'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
-        'weight' => '0',
-        'function' => array(
-          'islandora_fits_create_techmd',
-        ),
-        'file' => drupal_get_path('module', 'islandora_fits') . '/includes/derivatives.inc',
-      );
+    $derivatives[] = array(
+      'source_dsid' => 'OBJ',
+      'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
+      'weight' => '0',
+      'function' => array(
+        'islandora_fits_create_techmd',
+      ),
+      'file' => drupal_get_path('module', 'islandora_fits') . '/includes/derivatives.inc',
+    );
   }
   return $derivatives;
 }

--- a/islandora_fits.module
+++ b/islandora_fits.module
@@ -59,17 +59,19 @@ function islandora_fits_theme() {
  * Implements hook_islandora_derivative().
  */
 function islandora_fits_islandora_derivative() {
-  return array(
-    array(
-      'source_dsid' => 'OBJ',
-      'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
-      'weight' => '0',
-      'function' => array(
-        'islandora_fits_create_techmd',
-      ),
-      'file' => drupal_get_path('module', 'islandora_fits') . '/includes/derivatives.inc',
-    ),
-  );
+  $derivatives = array();
+  if (variable_get('islandora_fits_do_derivatives', TRUE)) {
+      $derivatives[] = array(
+        'source_dsid' => 'OBJ',
+        'destination_dsid' => variable_get('islandora_fits_techmd_dsid', 'TECHMD'),
+        'weight' => '0',
+        'function' => array(
+          'islandora_fits_create_techmd',
+        ),
+        'file' => drupal_get_path('module', 'islandora_fits') . '/includes/derivatives.inc',
+      );
+  }
+  return $derivatives;
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1999
_Comment from committers call June 15, 2017: "We should fix these quickly however, i.e., before the next release."_

# What does this Pull Request do?

Changes the mechanism for validating an admin form where the user has to enter a system path. Currently, whatever the user inputs is passed, unsanitized, into a call to exec(). As a side effect, this change adds a toggle for disabling this module's derivatives.

_This (FITS) implementation is a proof of concept that can be extended to the other modules identified in https://jira.duraspace.org/browse/ISLANDORA-1999._ 

# What's new?

* The admin form uses `is_executable($fits_path)` instead of `exec("stat $fits_path")` to verify whether the path is OK (used by ajax to show the user-friendly green-checkbox/red-x message).
* The admin form now validates, too - it does not allow you to save an invalid path (which would get called later by the derivative code)
* The admin form now includes a checkbox to "Run FITS derivatives locally" (checked by default). Unchecking this allows you to save the form if you can not/will not provide a valid path to an executable (e.g. you don't have FITS installed on your system, but you still want to display FITS metadata).
* If the user specifies that they do _not_ want to run FITS derivatives locally, the derivative function returns early with a message stating why it was skipped. 

# How should this be tested?

## Replicate the problem
* In the FITS path textfield, enter something like `foo; touch /tmp/fits-is-insecure`. Voila, you have created a file on the filesystem. With a little imagination, you can come up with a cool exploit. 

## Test the solution:
* Verify that the above command no longer gets executed. 
* Confirm that this method of testing the FITS path is no worse than the previous methods (at the time of writing this PR it uses `is_executable()` alone)
* Verify that an invalid path is never passed to `exec()` during form validation or derivative calls[1]

# Additional Notes:
[1] legacy paths (saved before this PR) will not be validated before being called in the derivative function... I think this may be a worthwhile risk to take to avoid extra validation in the derivative function. I chose to put path validation in the admin form, rather than the derivative call, to be more transparent to the user about what's going on, and to avoid validating the same path twice which felt a little repetitive.

* Does this change require documentation to be updated?  **Yes - the README should show the new configuration options.**
* Does this change add any new dependencies? **No**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **No**
* Could this change impact execution of existing code? **No**

# Interested parties
Tag @DonRichards @qadan @dannylamb mentioned on the ticket,  @mjordan maintainer. 